### PR TITLE
[fixed] didn't clear filename

### DIFF
--- a/server.c
+++ b/server.c
@@ -103,6 +103,7 @@ void connection_handler(int sockfd) {
 
     /* sending this file */
     file_sending_handler(sockfd, filename);
+    memset(filename, '\0', MAX_SIZE);
   }
 
   printf("[INFO] Connection closed (id: %d)\n", sockfd);


### PR DESCRIPTION
bug happened when client request filename as follow order
```
test.png
lab3_2_spec.pdf
test.txt
```

server will get 
```
test.png
lab3_2_spec.pdf
test.txtpec.pdf
```
and failed cause getting wrong filename.